### PR TITLE
Add GPU inference task!  Update all methods to preserve image type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 #
 # update history:
 # 08/20/20 - changed to nvidia base for DL methods
+# 08/29/20 - changed to nvidia cuda:10.0-base and pinned torch and monai versions (tested with NV drivers 435.21)
  
-FROM nvidia/cuda
+FROM nvidia/cuda:10.0-base
 
 RUN apt-get update -y
 RUN apt-get install -y lsof
@@ -11,11 +12,12 @@ RUN apt-get install -y lsof
 RUN apt-get install -y python3
 RUN apt-get install -y python3-pip
 RUN pip3 install --no-cache-dir pillow
-RUN pip3 install torch
-RUN pip3 install monai
+RUN pip3 install torch==1.4.0
+RUN pip3 install monai==0.2.0
 
 ADD setup.sh /tmp/setup.sh
 ADD snapshot.sh /tmp/snapshot.sh
+COPY unet_368x368_segment_model.pth /tmp/unet_368x368_segment_model.pth
 ADD script.py /tmp/script.py
 RUN chmod 0755 /tmp/snapshot.sh
 RUN chmod 0755 /tmp/setup.sh

--- a/Readme.md
+++ b/Readme.md
@@ -29,12 +29,16 @@ A docker container has been designed to run imaging algorithms as needed.  The c
   ```sh
   export taskName=threshold
   ```
+    or
+  ```sh
+  export taskName=inference
+  ```
   For test purpose the **test** module will just process an image and output a 128 x 128 thumbnail of it.  The **threshold** algorithm processes single channel SEM images to remove
-  background values (replacing the background with black).
+  background values (replacing the background with black). The **inference** tasks performs forward inferencing using a UNET network to perform segmentation used a pre-trained network. 
 
 2. Run docker image
   ```sh
-  docker run -id -v $FIBSEM/snapshot:/snapshot \
+  docker run --gpu all -id -v $FIBSEM/snapshot:/snapshot \
   -v $FIBSEM/repo:/repo -v $FIBSEM/dataset/input:/input \
   -v $FIBSEM/dataset/output:/output  -e module=$taskName \
   $imageName

--- a/repo/inference.py
+++ b/repo/inference.py
@@ -1,0 +1,86 @@
+import os
+from PIL import Image
+
+import torch
+import numpy as np
+import torch
+import monai
+from monai.transforms import \
+    Compose, LoadPNGd, AddChanneld,AsChannelFirstd, ScaleIntensityRanged, \
+    ToTensord, ScaleIntensityd, CastToTyped, Resized
+from monai.networks.layers import Norm
+
+
+
+def run(file, inputMount, outputMount):
+  inputPath = os.path.join(inputMount, file.split('/')[-1])
+  outputPath = os.path.join(outputMount, file.split('/')[-1])
+  print("attempting to infer cell clusters")
+  try:
+
+    # open the image only to find its size
+    with Image.open(inputPath) as input_img:
+        input_bbox = input_img.getbbox()
+        input_width = input_bbox[2]-input_bbox[0]
+        input_height = input_bbox[3]-input_bbox[1]
+        #print('input image size:',input_width,input_height)
+
+    # instantiate the model
+    # standard PyTorch program style: create UNet, DiceLoss and Adam optimizer
+    #print('checking for cuda device')
+    device = torch.device('cuda:0')
+    model = monai.networks.nets.UNet(dimensions=2, in_channels=3, out_channels=2, channels=(16, 32, 64, 128, 256),
+                                     strides=(2, 2, 2, 2), num_res_units=2, norm=Norm.BATCH).to(device)
+
+    print('attempting load of pretrained network from /tmp directory')
+    # read in the pretrained model
+    model.load_state_dict(torch.load('/tmp/unet_368x368_segment_model.pth'))
+    #print('loading complete')
+    model.eval()
+    NETWORK_IMAGE_SIZE=368
+
+    # define xforms in MONAI to prepare imagery for PyTorch inferencing
+    infer_transforms = Compose([
+        LoadPNGd(keys=['image']),
+        AsChannelFirstd(keys=['image']),
+        Resized(keys=['image'],spatial_size=(NETWORK_IMAGE_SIZE,NETWORK_IMAGE_SIZE),mode='bilinear',align_corners=False),
+        CastToTyped(keys=['image'],dtype='float32'),
+        ScaleIntensityd(keys=['image'], minv=0.0, maxv=1.0),
+        ToTensord(keys=['image'])
+    ])
+
+    # create and load a Monai dataset composed of the single image, because the transforms 
+    # are performed automatically in MONAI. A spec for the image is needed by the Dataset definition
+    infer_files = [{'image': inputPath}]
+    infer_ds = monai.data.Dataset(infer_files, transform=infer_transforms)
+    infer_loader = monai.data.DataLoader(infer_ds, batch_size=1)
+
+    # get the transformed single image out of the dataset
+    input_data = monai.utils.misc.first(infer_loader)
+
+    # move the tensor to the GPU
+    input_tensor= input_data['image'].to(device)
+
+    # run the forward prediction
+    predict_tensor = model(input_tensor)
+    #print('inference complete. preparing output')
+
+    # get the result back from the GPU and drop the first dimension
+    infer_array = predict_tensor.detach().cpu().squeeze()
+
+    # rearrange to num channels last and make it a single channel binary image
+    pred_array = torch.argmax(np.transpose(infer_array,(1,2,0)),dim=2)
+
+    # convert type back from torch to numpy
+    prediction = pred_array.numpy()
+
+    # write the file out in a viewable way, the output image is resized to match the
+    # input image size for convenience, even though inferencing is always done at the 
+    # size of the pretrained network
+    outimg = Image.fromarray(prediction.astype('uint8')*255)
+    resized = outimg.resize((input_width,input_height))
+    print('saving segmentation to:',outputPath)
+    resized.save(outputPath)
+    
+  except OSError:
+      print("cannot create inference image for", file)

--- a/repo/test.py
+++ b/repo/test.py
@@ -8,6 +8,6 @@ def run(file, inputMount, outputMount):
   try:
     with Image.open(inputPath) as im:
       im.thumbnail(size)
-      im.save(outputPath, "JPEG")
+      im.save(outputPath)
   except OSError:
     print("cannot create thumbnail for", file)

--- a/repo/threshold.py
+++ b/repo/threshold.py
@@ -28,6 +28,6 @@ def run(file, inputMount, outputMount):
       flip_im = np.flip(rot_im,1)
       # convert back to image and save as TIFF
       out_image = Image.fromarray(flip_im)
-      out_image.save(outputPath, "TIFF")
+      out_image.save(outputPath)
   except OSError:
       print("cannot create threshold image for", file)


### PR DESCRIPTION
A new task, inference.py, is added, along with a pretrained weights file for a 2D UNET segmentation.   Input images need to have 3-channels (e.g. RGB) but can be arbitrary size.  The images are scaled to 368x368 prior to inferencing.    Also, it was observed that if a PNG file was sent to the test.py method, the output file would have a .png extension, but it would actually be a JPEG file.  To fix this, the type specification of the file to write (e.g "TIFF","JPEG") was removed.  Now, multiple file types work.  